### PR TITLE
Python2 removal: remove six dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
     author_email='dsteele@gmail.com',
     url='https://davesteele.github.io/viagee/',
     scripts=['viagee'],
-    requires=['six'],
+    requires=[],
     data_files=[
         ('share/icons/hicolor/16x16/apps', ['icons/16x16/viagee.png']),
 #        ('share/icons/hicolor/24x24/apps', ['icons/24x24/viagee.png']),

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,7 +3,6 @@ import pytest
 from mock import Mock
 import tempfile
 import os
-import urllib
 
 
 @pytest.fixture()

--- a/test/test_body.py
+++ b/test/test_body.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import pytest
-import re
-from six.moves import urllib
+import urllib.parse
 
 import viagee
 

--- a/test/test_gmailapi.py
+++ b/test/test_gmailapi.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import pytest
-
-from six.moves import urllib
+import urllib.parse
 
 import viagee
 

--- a/viagee.py
+++ b/viagee.py
@@ -27,6 +27,7 @@ import time
 import unicodedata
 import urllib.request
 import webbrowser
+from configparser import ConfigParser
 from contextlib import contextmanager
 from email import encoders
 from email.mime.audio import MIMEAudio
@@ -38,7 +39,6 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 
 import gi
 from gi.repository import Gio  # noqa
-from six.moves.configparser import ConfigParser
 
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk  # noqa


### PR DESCRIPTION
this is a tiny cleanup.

`six` was only usefull for codebases that attempted to support Python2 +3
