### PR TITLE
Drop empty screenshot element from appdata

### DIFF
--- a/viagee.appdata.xml.in
+++ b/viagee.appdata.xml.in
@@ -27,8 +27,6 @@ etc.</_p>
 <developer_name>David Steele</developer_name>
 <update_contact>dsteele_AT_gmail.com</update_contact>
 <translation type="gettext">viagee</translation>
-<screenshots>
-</screenshots>
 <releases>
     <!-- Get timestamp with 'date +%s' -->
     <release version="3.7.1" timestamp="1695009728"></release>


### PR DESCRIPTION
This prevents `appstream-util validate-relax …` from making the following complaint:

```
viagee.appdata.xml: FAILED:
• tag-invalid           : Expected children for tag
Validation of files failed
```

Perhaps this is related to #3?